### PR TITLE
Convert bare pointers to unique_ptr

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.cc
@@ -50,7 +50,7 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
   gemPadDigiProducer_ = conf.existsAs<edm::InputTag>("GEMPadDigiProducer")?conf.getParameter<edm::InputTag>("GEMPadDigiProducer"):edm::InputTag("");
   rpcDigiProducer_ = conf.existsAs<edm::InputTag>("RPCDigiProducer")?conf.getParameter<edm::InputTag>("RPCDigiProducer"):edm::InputTag("");
   checkBadChambers_ = conf.getParameter<bool>("checkBadChambers");
-  lctBuilder_ = new CSCTriggerPrimitivesBuilder(conf); // pass on the conf
+  lctBuilder_.reset( new CSCTriggerPrimitivesBuilder(conf) ); // pass on the conf
   
   wire_token_ = consumes<CSCWireDigiCollection>(wireDigiProducer_);
   comp_token_ = consumes<CSCComparatorDigiCollection>(compDigiProducer_);
@@ -75,7 +75,6 @@ CSCTriggerPrimitivesProducer::CSCTriggerPrimitivesProducer(const edm::ParameterS
 CSCTriggerPrimitivesProducer::~CSCTriggerPrimitivesProducer() {
   LogDebug("L1CSCTrigger")
     << "deleting trigger primitives after " << iev << " events.";
-  delete lctBuilder_;
 }
 
 //void CSCTriggerPrimitivesProducer::beginRun(const edm::EventSetup& setup) {

--- a/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
+++ b/L1Trigger/CSCTriggerPrimitives/plugins/CSCTriggerPrimitivesProducer.h
@@ -59,7 +59,7 @@ class CSCTriggerPrimitivesProducer : public edm::one::EDProducer<edm::one::Share
   bool debugParameters_;
   // switch to for enabling checking against the list of bad chambers
   bool checkBadChambers_;
-  CSCTriggerPrimitivesBuilder* lctBuilder_;
+  std::unique_ptr<CSCTriggerPrimitivesBuilder> lctBuilder_;
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -148,8 +148,8 @@ CSCMotherboard::CSCMotherboard(unsigned endcap, unsigned station,
 
   infoV = tmbParams.getParameter<int>("verbosity");
 
-  alct = new CSCAnodeLCTProcessor(endcap, station, sector, subsector, chamber, alctParams, commonParams);
-  clct = new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, tmbParams);
+  alct.reset( new CSCAnodeLCTProcessor(endcap, station, sector, subsector, chamber, alctParams, commonParams) );
+  clct.reset( new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, tmbParams) );
 
   //if (theStation==1 && CSCTriggerNumbering::ringFromTriggerLabels(theStation, theTrigChamber)==2) infoV = 3;
 
@@ -176,8 +176,8 @@ CSCMotherboard::CSCMotherboard() :
 
   early_tbins = 4;
 
-  alct = new CSCAnodeLCTProcessor();
-  clct = new CSCCathodeLCTProcessor();
+  alct.reset( new CSCAnodeLCTProcessor() );
+  clct.reset( new CSCCathodeLCTProcessor() );
   mpc_block_me1a      = def_mpc_block_me1a;
   alct_trig_enable    = def_alct_trig_enable;
   clct_trig_enable    = def_clct_trig_enable;
@@ -196,8 +196,6 @@ CSCMotherboard::CSCMotherboard() :
 }
 
 CSCMotherboard::~CSCMotherboard() {
-  if (alct) delete alct;
-  if (clct) delete clct;
 }
 
 void CSCMotherboard::clear() {

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -75,10 +75,10 @@ class CSCMotherboard
   void setConfigParameters(const CSCDBL1TPParameters* conf);
 
   /** Anode LCT processor. */
-  CSCAnodeLCTProcessor* alct;
+  std::unique_ptr<CSCAnodeLCTProcessor> alct;
 
   /** Cathode LCT processor. */
-  CSCCathodeLCTProcessor* clct;
+  std::unique_ptr<CSCCathodeLCTProcessor> clct;
 
  // VK: change to protected, to allow inheritance
  protected:

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.cc
@@ -82,7 +82,7 @@ CSCMotherboardME11::CSCMotherboardME11(unsigned endcap, unsigned station,
   edm::ParameterSet clctParams = conf.getParameter<edm::ParameterSet>("clctSLHC");
   edm::ParameterSet tmbParams = conf.getParameter<edm::ParameterSet>("tmbSLHC");
 
-  clct1a = new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, tmbParams);
+  clct1a.reset( new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, tmbParams) );
   clct1a->setRing(4);
 
   match_earliest_alct_me11_only = tmbParams.getParameter<bool>("matchEarliestAlctME11Only");
@@ -114,7 +114,7 @@ CSCMotherboardME11::CSCMotherboardME11() : CSCMotherboard()
 {
   // Constructor used only for testing.
 
-  clct1a = new CSCCathodeLCTProcessor();
+  clct1a.reset( new CSCCathodeLCTProcessor() );
   clct1a->setRing(4);
 
   pref[0] = match_trig_window_size/2;
@@ -128,7 +128,6 @@ CSCMotherboardME11::CSCMotherboardME11() : CSCMotherboard()
 
 CSCMotherboardME11::~CSCMotherboardME11()
 {
-  if (clct1a) delete clct1a;
 }
 
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11.h
@@ -54,7 +54,7 @@ class CSCMotherboardME11 : public CSCMotherboard
   void setConfigParameters(const CSCDBL1TPParameters* conf);
 
   /** additional Cathode LCT processor for ME1a */
-  CSCCathodeLCTProcessor* clct1a;
+  std::unique_ptr<CSCCathodeLCTProcessor> clct1a;
 
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs1a();
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs1b();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.cc
@@ -201,7 +201,7 @@ CSCMotherboardME11GEM::CSCMotherboardME11GEM(unsigned endcap, unsigned station,
   const edm::ParameterSet clctParams(conf.getParameter<edm::ParameterSet>("clctSLHC"));
   const edm::ParameterSet me11tmbParams(conf.getParameter<edm::ParameterSet>("me11tmbSLHCGEM"));
 
-  clct1a = new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, me11tmbParams);
+  clct1a.reset( new CSCCathodeLCTProcessor(endcap, station, sector, subsector, chamber, clctParams, commonParams, me11tmbParams) );
   clct1a->setRing(4);
 
   match_earliest_alct_me11_only = me11tmbParams.getParameter<bool>("matchEarliestAlctME11Only");
@@ -310,7 +310,7 @@ CSCMotherboardME11GEM::CSCMotherboardME11GEM() : CSCMotherboard()
 {
   // Constructor used only for testing.
 
-  clct1a = new CSCCathodeLCTProcessor();
+  clct1a.reset( new CSCCathodeLCTProcessor() );
   clct1a->setRing(4);
 
   pref[0] = match_trig_window_size/2;
@@ -324,7 +324,6 @@ CSCMotherboardME11GEM::CSCMotherboardME11GEM() : CSCMotherboard()
 
 CSCMotherboardME11GEM::~CSCMotherboardME11GEM()
 {
-  if (clct1a) delete clct1a;
 }
 
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboardME11GEM.h
@@ -74,7 +74,7 @@ class CSCMotherboardME11GEM : public CSCMotherboard
   void setConfigParameters(const CSCDBL1TPParameters* conf);
 
   /** additional Cathode LCT processor for ME1a */
-  CSCCathodeLCTProcessor* clct1a;
+  std::unique_ptr<CSCCathodeLCTProcessor> clct1a;
 
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs1a();
   std::vector<CSCCorrelatedLCTDigi> readoutLCTs1b();

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -111,7 +111,7 @@ CSCTriggerPrimitivesBuilder::CSCTriggerPrimitivesBuilder(const edm::ParameterSet
   m_maxBX = conf.getParameter<int>("MaxBX");
 
   // Init MPC
-  m_muonportcard = new CSCMuonPortCard(conf);
+  m_muonportcard.reset( new CSCMuonPortCard(conf) );
 }
 
 //------------
@@ -136,7 +136,6 @@ CSCTriggerPrimitivesBuilder::~CSCTriggerPrimitivesBuilder()
       }
     }
   }
-  delete m_muonportcard;
 }
 
 //------------

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.h
@@ -117,7 +117,7 @@ class CSCTriggerPrimitivesBuilder
   const RPCGeometry* rpc_g;
 
   /** Pointer to MPC processor. */
-  CSCMuonPortCard* m_muonportcard;
+  std::unique_ptr<CSCMuonPortCard> m_muonportcard;
 };
 
 #endif


### PR DESCRIPTION
I think the code was actually all fine, but I changed the bare pointers to smart pointers as David requested.  If nothing else it makes the code clearer that there are no leaks.  Also technically safer since it refuses to compile if there is a copy that would make two instances point to the same object.
I haven't changed the pointer array `tmb_` in `CSCTriggerPrimitivesBuilder` because I wasn't sure about the overhead though, I'll ask David on the original PR if he wants that changed too.

If you accept this pull request the original PR should be automatically updated.