### PR TITLE
First version of 1/8th strip GEM-CLCT matching

### DIFF
--- a/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMatcher.h
+++ b/L1Trigger/CSCTriggerPrimitives/interface/CSCGEMMatcher.h
@@ -24,7 +24,10 @@ class CSCGEMMatcher {
 public:
   typedef std::vector<GEMInternalCluster> GEMInternalClusters;
 
-  CSCGEMMatcher(unsigned endcap, unsigned station, unsigned chamber, const edm::ParameterSet& luts);
+  CSCGEMMatcher(int endcap, unsigned station, unsigned chamber, const edm::ParameterSet& luts);
+
+  // calculate slope correction
+  int CSCGEMSlopeCorrector(const bool isFacing, const bool isL1orCopad, const int cscSlope) const;
 
   // match by BX
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
@@ -105,11 +105,13 @@ CSCGEMMatcher::GEMInternalClusters CSCGEMMatcher::matchingClustersLoc(const CSCC
     }
 
     // for single clusters in L2
-    if (cl.id().layer() == 1) {
+    else if (cl.id().layer() == 2) {
       key_es = cl.layer2_middle_es();
       if (station_ == 1 and clct.getKeyStrip() > CSCConstants::MAX_HALF_STRIP_ME1B)
         key_es = cl.layer2_middle_es_me1a();
     }
+    
+    else edm::LogWarning("CSCGEMMatcher") << "cluster.id().layer =" << cl.id().layer() << " out of acceptable range 1-2!";
 
     // matching by 1/8-strip
     // need new function from Denis here!!!

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMatcher.cc
@@ -4,6 +4,7 @@
 #include "DataFormats/CSCDigi/interface/CSCConstants.h"
 #include "DataFormats/CSCDigi/interface/CSCALCTDigi.h"
 #include "DataFormats/CSCDigi/interface/CSCCLCTDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <algorithm>
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCGEMMotherboard.cc
@@ -338,14 +338,15 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     return thisLCT;
   }
 
+  std::cout<<pattern << quality << bx << keyStrip << keyWG << bend << valid <<std::endl;//stops compiler errors -- fixit --
   // ALCT-CLCT-GEM and ALCT-CLCT-2GEM cases
-  if (alct.isValid() and clct.isValid() and gem1.isValid()) {
+  if (alct.isValid() and clct.isValid()){// and gem1.isValid()) { //removed for the moment, as GEMInternalCluster has no function "isValid()", gem1 is not defined either -- fixit --
 
     pattern = encodePattern(clct.getPattern());
     if (runCCLUT_) {
-    quality = qualityAssignment_->findQualityGEMv2(alct, clct, 1);
+      quality = qualityAssignment_->findQualityGEMv2(alct, clct, 1);
     } else {
-    quality = qualityAssignment_->findQualityGEMv1(alct, clct, 1);
+      quality = qualityAssignment_->findQualityGEMv1(alct, clct, 1);
     }
     bx = alct.getBX();
     keyStrip = clct.getKeyStrip();
@@ -353,23 +354,24 @@ CSCCorrelatedLCTDigi CSCGEMMotherboard::constructLCTsGEM(const CSCALCTDigi& alct
     bend = clct.getBend();
     thisLCT.setALCT(getBXShiftedALCT(alct));
     thisLCT.setCLCT(getBXShiftedCLCT(clct));
-    thisLCT.setGEM1(gem1);
+    //thisLCT.setGEM1(gem); //does currently expect setGEM1(const GEMPadDigi& gem) , but gets GEMInternalCluster -- fixit --
     thisLCT.setType(CSCCorrelatedLCTDigi::ALCTCLCTGEM);
     if (runCCLUT_) {
-    thisLCT.setRun3(true);
-    // 4-bit slope value derived with the CCLUT algorithm
-    thisLCT.setSlope(clct.getSlope());
-    thisLCT.setQuartStrip(clct.getQuartStrip());
-    thisLCT.setEighthStrip(clct.getEighthStrip());
-    thisLCT.setRun3Pattern(clct.getRun3Pattern());
+      thisLCT.setRun3(true);
+      // 4-bit slope value derived with the CCLUT algorithm
+      thisLCT.setSlope(clct.getSlope());
+      thisLCT.setQuartStrip(clct.getQuartStrip());
+      thisLCT.setEighthStrip(clct.getEighthStrip());
+      thisLCT.setRun3Pattern(clct.getRun3Pattern());
+    }
 
   }
 
   // CLCT-2GEM case
-  else if (clct.isValid() and gem1.isValid()) {
+  else if (clct.isValid()){// and gem1.isValid()) { //gem1 is not defined, isValid() doesn't exist for GEMInternalCluster -- fixit --
   }
   // ALCT-2GEM case
-  else if (alct.isValid() and gem1.isValid()) {
+  else if (alct.isValid()){// and gem1.isValid()) { //gem1 is not defined, isValid() doesn't exist for GEMInternalCluster -- fixit -- 
   }
   /*
 


### PR DESCRIPTION
#### PR description:

Ascertains baseline compilability, commenting fixits for necessary intermediate changes
Introduces slope correction subfunction int CSCGEMMatcher::CSCGEMSlopeCorrector(bool isFacing, bool isL1orCopad, int cscSlope) const
Implements this subfunction to correct for slope within clct matching subfunction

#### PR validation:

Basic algorithm in DeltaPhi units and self-calculated 1/8th strip units validated in ROOT ntuples, so far.
Compilability verified in CMSSW 12_0_X_2021-04-22-1100
